### PR TITLE
Updating readme with boost 1.69 and Ledger V3.1.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,11 @@ current directory as the repository root.*
     Use a different URL above if you are using a fork of the original
     instructions.
 
-#.  `Download <https://dl.bintray.com/boostorg/release/1.68.0/source/
-    boost_1_68_0.zip>`__ and extract ``boost_1_68_0`` to the root of this
+#.  `Download <https://dl.bintray.com/boostorg/release/1.69.0/source/
+    boost_1_69_0.zip>`__ and extract ``boost_1_69_0`` to the root of this
     repository, then build Boost using the following at the command prompt::
 
-        ren boost_1_68_0 boost
+        ren boost_1_69_0 boost
         cd boost
         .\bootstrap.bat
         .\b2.exe link=static runtime-link=static threading=multi ^


### PR DESCRIPTION
Was able to successfully build latest ledger with boost 1.69 and instructions found in README. Thanks for that.